### PR TITLE
fix/tom/dmmf-performance

### DIFF
--- a/src/lib/nestedOperations.ts
+++ b/src/lib/nestedOperations.ts
@@ -44,13 +44,15 @@ export function withNestedOperations<
   $allNestedOperations: (params: NestedParams<ExtArgs>) => Promise<any>;
   dmmf?: BaseDMMF;
 }): typeof $rootOperation {
+  const relationsByModel = getRelationsByModel(dmmf ?? Prisma.dmmf);
+
   return async (rootParams) => {
     let calls: OperationCall<ExtArgs>[] = [];
 
     try {
       const executionResults = await Promise.allSettled(
         extractNestedOperations(
-          getRelationsByModel(dmmf ?? Prisma.dmmf),
+          relationsByModel,
           rootParams as NestedParams<ExtArgs>
         ).map((nestedOperation) =>
           executeOperation(


### PR DESCRIPTION
I believe I’ve found a performance issue in [nestedOperations.ts](https://github.com/round-cash/prisma-extension-nested-operations/blob/0ff6c2dc635f6446af750584b67ba537c1b3eae2/src/lib/nestedOperations.ts#L53C11-L53C30)

The line in question is executed on every database operation, which can cause significant performance degradation when dmmf.datamodel.models is large, due to repeated iterations.

My suggestion is to move the call to getRelationsByModel(dmmf ?? Prisma.dmmf) to after line 46, so it won’t be executed on every DB operation. 
